### PR TITLE
execute refresh_misc on configure

### DIFF
--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -16,7 +16,8 @@
  *
  *  0.4   (2021-12-12) => Added changes from SmartThings driver v1.2.0
  *  0.5   (2021-12-15) => Added possibility to set outdoor temperature from command and fixed power reporting event
- *  0.6   (2022-01-01) => Fix duplicate events and add event descriptionText attribute
+ *  0.6   (2022-01-01) => Fixed duplicate events and added event descriptionText attribute
+ *  0.7   (2022-01-09) => Added setClockTime command and updated time on "configure" command
  *  Author(0.4+): fblackburn
  */
 
@@ -164,6 +165,8 @@ void configure() {
         displayed: false,
         data: [protocol: 'zigbee', hubHardwareId: device.hub.hardwareID],
     )
+
+    refresh_misc()
 }
 
 void initialize() {

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -95,6 +95,8 @@ metadata
                 constraints: ['Outdoor', 'Setpoint'],
             ]]
         )
+        command('setClockTime')
+
         command 'emergencyHeat', [[name: 'Not Supported']]
         command 'auto', [[name: 'Not Supported']]
         command 'cool', [[name: 'Not Supported']]
@@ -323,18 +325,9 @@ void displayTemperature(String choice) {
     state.displayTemperature = choice
 }
 
-void refresh_misc() {
+void setClockTime() {
     List cmds = []
-
-    // Backlight
-    if (backlightAutoDimParam == 'On Demand') {
-        cmds += zigbee.writeAttribute(0x0201, 0x0402, DataType.ENUM8, 0x0000)
-    }
-    else {
-        cmds += zigbee.writeAttribute(0x0201, 0x0402, DataType.ENUM8, 0x0001)
-    }
-
-    // TimeFormat
+    // Time Format
     if (timeFormatParam == '12 Hour') {
         // 12 Hour
         cmds += zigbee.writeAttribute(0xFF01, 0x0114, 0x30, 0x0001)
@@ -354,6 +347,20 @@ void refresh_misc() {
     Integer currentTimeToSend = zigbee.convertHexToInt(hex(currentTimeToDisplay))
     cmds += zigbee.writeAttribute(0xFF01, 0x0020, DataType.UINT32, currentTimeToSend, [mfgCode: '0x119C'])
 
+    sendCommands(cmds)
+}
+
+void refresh_misc() {
+    List cmds = []
+
+    // Backlight
+    if (backlightAutoDimParam == 'On Demand') {
+        cmds += zigbee.writeAttribute(0x0201, 0x0402, DataType.ENUM8, 0x0000)
+    }
+    else {
+        cmds += zigbee.writeAttribute(0x0201, 0x0402, DataType.ENUM8, 0x0001)
+    }
+
     // °C or °F
     if (state?.scale == 'C') {
         cmds += zigbee.writeAttribute(0x0204, 0x0000, DataType.ENUM8, 0)  // °C on thermostat display
@@ -363,6 +370,7 @@ void refresh_misc() {
     }
 
     sendCommands(cmds)
+    setClockTime()
 }
 
 void setHeatingSetpoint(Double degrees) {


### PR DESCRIPTION
why: after electrical failure, thermostat lose time. So we need to send
command to set clock and/or only send configure command to set
everything right

That's what the official Sinope driver does