### PR TITLE
Pull request for fix-power-outage

### DIFF
--- a/drivers/Plug-Sinope-SP2600ZB.groovy
+++ b/drivers/Plug-Sinope-SP2600ZB.groovy
@@ -76,10 +76,6 @@ void configure() {
         unschedule()
     } catch (ignored) { }
 
-    if (device.currentValue('energy') == null) {
-        sendEvent(name: 'energy', value: 0, unit: 'kWh')
-    }
-
     List cmds = []
     cmds += zigbee.configureReporting(0x0006, 0x0000, DataType.BOOLEAN, 0, 600, null) // State
     Integer powerChange = settings.powerChange == null ? getDefaultPowerChange() : settings.powerChange

--- a/drivers/Plug-Sinope-SP2600ZB.groovy
+++ b/drivers/Plug-Sinope-SP2600ZB.groovy
@@ -3,7 +3,8 @@
 /**
  *  Sinope Zigbee Plug (SP2600ZB) Device Driver for Hubitat
  *
- *  1.0 (2022-12-18): initial release
+ *  1.0 (2022-12-18): Initial release
+ *  1.1 (2023-01-15): Set power to 0 when below treshold
  *  Author: fblackburn
  *  Inspired by:
  *    - Sinope => https://github.com/SmartThingsCommunity/SmartThingsPublic/tree/master/devicetypes/sinope-technologies

--- a/drivers/Plug-Sinope-SP2600ZB.groovy
+++ b/drivers/Plug-Sinope-SP2600ZB.groovy
@@ -121,7 +121,7 @@ Map parse(String description) {
         log.warn "SP2600ZB >> parse(descMap) ==> Unhandled attribute: ${descMap}"
     }
 
-    if (event.name && event.value) {
+    if (event.name != null && event.value != null) {
         event.descriptionText = "${device.getLabel()} ${event.name} is ${event.value}"
         if (event.unit) {
             event.descriptionText = "${event.descriptionText}${event.unit}"

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -195,6 +195,9 @@ List<Map> parse(String description) {
     }
     if (descMap.additionalAttrs) {
         // From test, only (cluster: 0B04 / attrId: 0505) has additionalAttrs
+        if (settings.trace) {
+            log.trace "TH112XZB >> Found additionalAttrs: ${descMap}"
+        }
         descMap.additionalAttrs.each { Map attribute ->
             attribute.cluster = attribute.cluster ? attribute.cluster : descMap.cluster
             events.add(extractEvent(attribute))

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -245,6 +245,8 @@ void refresh() {
     cmds += zigbee.readAttribute(0x0201, 0x0008) // PI heating demand
     cmds += zigbee.readAttribute(0x0201, 0x001C) // System Mode
     cmds += zigbee.readAttribute(0x0204, 0x0001) // Keypad lock
+    cmds += zigbee.readAttribute(0x0B04, 0x0505) // RMS Voltage
+    cmds += zigbee.readAttribute(0x0B04, 0x0508) // RMS Current
     cmds += zigbee.readAttribute(0x0B04, 0x050B) // Active power
     cmds += zigbee.readAttribute(0x0B04, 0x050D) // Maximum power available
     cmds += zigbee.readAttribute(0x0702, 0x0000) // Total Energy

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -194,12 +194,13 @@ List<Map> parse(String description) {
         }
     }
     if (descMap.additionalAttrs) {
-        // From test, only (cluster: 0B04 / attrId: 0505) has additionalAttrs
+        // When many events from same cluster must be sent at the same time,
+        // device other events in additionalAttrs instead of sending several
         if (settings.trace) {
             log.trace "TH112XZB >> Found additionalAttrs: ${descMap}"
         }
         descMap.additionalAttrs.each { Map attribute ->
-            attribute.cluster = attribute.cluster ? attribute.cluster : descMap.cluster
+            attribute.cluster = descMap.cluster
             events.add(extractEvent(attribute))
         }
     }

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -480,7 +480,7 @@ private Map extractEvent(Map descMap) {
 
 private String generateDescription(Map event) {
     String description = null
-    if (event.name && event.value) {
+    if (event.name != null && event.value != null) {
         description = "${device.getLabel()} ${event.name} is ${event.value}"
         if (event.unit) {
             description = "${description}${event.unit}"

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -3,7 +3,7 @@
 /**
  *  Thermostat Sinopé TH1123ZB-TH1124ZB Driver
  *
- *  1.0 (2022-12-31): initial release
+ *  1.0 (2022-12-31): Initial release
  *  1.1 (2022-01-04): Handled short circuit and rmsVoltage/rmsCurrent
  *  Author: fblackburn
  *  Inspired by:

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -4,6 +4,7 @@
  *  Thermostat Sinopé TH1123ZB-TH1124ZB Driver
  *
  *  1.0 (2022-12-31): initial release
+ *  1.1 (2022-01-04): Handled short circuit and rmsVoltage/rmsCurrent
  *  Author: fblackburn
  *  Inspired by:
  *    - Sinope => https://github.com/SmartThingsCommunity/SmartThingsPublic/tree/master/devicetypes/sinope-technologies

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -30,10 +30,10 @@ metadata
         capability 'Lock'
         capability 'PowerMeter'
         capability 'EnergyMeter'
+        capability 'CurrentMeter'
+        capability 'VoltageMeasurement'
 
         attribute 'maxPower', 'number'
-        attribute 'rmsVoltage', 'number'
-        attribute 'rmsCurrent', 'number'
 
         command(
             'setThermostatMode',
@@ -455,12 +455,12 @@ private Map extractEvent(Map descMap) {
         event.value = getLockMap()[descMap.value]
     } else if (descMap.cluster == '0B04' && descMap.attrId == '0505') {
         // This event seems to be triggered automatically after each 18 hours
-        event.name = 'rmsVoltage'
+        event.name = 'voltage'
         event.value = getVoltage(descMap.value)
         event.unit = 'V'
     } else if (descMap.cluster == '0B04' && descMap.attrId == '0508') {
-        event.name = 'rmsCurrent'
-        event.value = getCurrent(descMap.value)
+        event.name = 'amperage'
+        event.value = getAmperage(descMap.value)
         event.unit = 'A'
     } else if (descMap.cluster == '0B04' && descMap.attrId == '0551') {
         BigInteger energy = getEnergy(descMap.value)
@@ -606,7 +606,7 @@ private Double getVoltage(String value) {
     return Integer.parseInt(value, 16) / 10
 }
 
-private Double getCurrent(String value) {
+private Double getAmperage(String value) {
     if (value == null) {
         return 0
     }

--- a/drivers/Thermostat-Sinope-TH1123ZB.groovy
+++ b/drivers/Thermostat-Sinope-TH1123ZB.groovy
@@ -32,6 +32,8 @@ metadata
         capability 'EnergyMeter'
 
         attribute 'maxPower', 'number'
+        attribute 'rmsVoltage', 'number'
+        attribute 'rmsCurrent', 'number'
 
         command(
             'setThermostatMode',
@@ -165,19 +167,19 @@ List<Map> parse(String description) {
         if (!description?.startsWith('catchall:')) {
             log.warn "TH112XZB >> parse(description) ==> Unhandled event: ${description}"
         }
-        return [:]
+        return []
     }
 
     Map descMap = zigbee.parseDescriptionAsMap(description)
-    List<Map> events = [parseMap(descMap)]
+    List<Map> events = [generateEvent(descMap)]
     if (descMap.additionalAttrs) {
         // From test, only (cluster: 0B04 / attrId: 0505) has additionalAttrs
         descMap.additionalAttrs.each { attribute ->
             attribute.cluster = attribute.cluster ? attribute.cluster : descMap.cluster
-            events += parseMap(attribute)
+            events += generateEvent(attribute)
         }
     }
-    return parseMap(descMap)
+    return events
 }
 
 void unlock() {
@@ -375,7 +377,7 @@ void handlePowerOutage() {
     setClockTime()
 }
 
-private List<Map> parseMap(Map descMap) {
+private Map generateEvent(Map descMap) {
     Map event = [:]
     if (descMap.cluster == '0201' && descMap.attrId == '0000') {
         String scale = getTemperatureScale()
@@ -452,7 +454,7 @@ private List<Map> parseMap(Map descMap) {
         event.unit = 'V'
     } else if (descMap.cluster == '0B04' && descMap.attrId == '0508') {
         event.name = 'rmsCurrent'
-        event.value = getCurrent(attribute.value)
+        event.value = getCurrent(descMap.value)
         event.unit = 'A'
     } else if (descMap.cluster == '0B04' && descMap.attrId == '0551') {
         BigInteger energy = getEnergy(descMap.value)


### PR DESCRIPTION
## th1123zb: handle power outage with wrong energy value

third party reading value will need to handle this case to avoid wrong
result (ex: influxdb --> use difference(nonNegative: true))

## th1123zb: handle rmsVoltage/rmsCurrent

rmsVoltage is sent automatically each day (18 hours)
It seems to be the only event with additionalAttrs property. So
refactoring code to better handle this scenario

## th1123zb: move private function to end of file


## th1123zb: bump version/changelog


## th1123zb: fix issue with previous refactor


## th1123zb: extract event creation to parse


## th1123zb: add RMS voltage/current on refresh


## th1123zb: add debug output when additionalAttrs


## fix description when value is 0


## th1123zb: use hubitat capability for volt/amp rms


## th1123zb: improve comment and removed unused logic


## th1123zb: remove unused initialization

why: was used in another implementation, not anymore
